### PR TITLE
Fix for Issue 17 - tc 567 LIBS envar

### DIFF
--- a/patches/PR3/README.md
+++ b/patches/PR3/README.md
@@ -1,0 +1,4 @@
+In test 567, LIBS is set during the first run of configure so it appears in state-env.c-native.r1, but on the second run of configure when the cache is picked up LIBS is not set, so it does not appear in state-env.c-native.r2. There is a macro that is generating a script that sets LIBS in the first case, but not the second. So then I did a search on this problem to see if anyone else ran into it before....
+Turns out yes, someone in 2005 ran into a related problem and there is a fix.
+https://lists.gnu.org/archive/html/bug-autoconf/2005-07/msg00018.html
+This fix is similar.  It will replace all envars that are set using double quotes to a null string using, with nothing, so that the subsequent comparison passes.

--- a/patches/PR3/local.at.patch
+++ b/patches/PR3/local.at.patch
@@ -1,0 +1,12 @@
+diff --git a/tests/local.at b/tests/local.at
+index 7318f92..f303f81 100644
+--- a/tests/local.at
++++ b/tests/local.at
+@@ -482,6 +482,7 @@ do
+   $SED '/^ac_cv_/ b skip
+ 	/^m4_defn([m4_re_word])=./ !d
+ 	/^[[^=]]*='\'''\''$/ d
++	/^[[^=]]*=""$/ d
+ 	/^a[[cs]]_/ d
+ 	: skip
+ 	/^OLDPWD=/ d


### PR DESCRIPTION
This fixes Issue 17.  See my comments made in
https://github.com/ZOSOpenTools/autoconfport/issues/17
for more details on the explanation.