### PR TITLE
set autom4te_perllibdir and AC_MACRODIR in .env

### DIFF
--- a/portcrtenv.sh
+++ b/portcrtenv.sh
@@ -8,5 +8,7 @@ if ! [ -f ./.env ]; then
 fi
 mydir="\${PWD}"
 export PATH="\${mydir}/bin:\$PATH"
+export autom4te_perllibdir=${install_dir}/share/autoconf
+export AC_MACRODIR=${install_dir}/share/autoconf
 zz
 exit 0


### PR DESCRIPTION
This should allow installing autoconf in a directory that is not the installation path specified during the build.