### PR TITLE
Added M4 path

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -19,6 +19,14 @@ zopen_append_to_env()
 cat <<EOF
 export autom4te_perllibdir=\${PWD}/share/autoconf
 export AC_MACRODIR=\${PWD}/share/autoconf
+
+#To set M4 variable path
+if [ -z "${M4_HOME}"  ]; then
+    echo "Ensure M4_HOME is set and re-source the .env"
+else
+    export M4="\$M4_HOME/bin/m4"
+fi
+
 EOF
 }
 


### PR DESCRIPTION
Added M4 path for autconf as the M4 was pointing to incorrect directory
and throwing below error:
autom4te: error: need GNU m4 1.4 or later: /usr/local/bin/m4

With the above path set, the autoconf is building without any issue

@MikeFultonDev @IgorTodorovskiIBM Please review the code.

Thank you!