### PR TITLE
Fix M4_HOME check

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -24,8 +24,8 @@ cat <<EOF
 export autom4te_perllibdir=\${PWD}/share/autoconf
 export AC_MACRODIR=\${PWD}/share/autoconf
 
-#To set M4 variable path
-if [ -z "${M4_HOME}"  ]; then
+# To set M4 variable path
+if [ -z "\${M4_HOME}"  ]; then
     echo "Ensure M4_HOME is set and re-source the .env"
 else
     export M4="\$M4_HOME/bin/m4"


### PR DESCRIPTION
```
if [ -z "${M4_HOME}"  ]; then
```
was replaced with:
```
if [ -z "/jenkins/zopen/usr/local/zopen/m4/m4-1.4.19.20230924_212310.zos"  ]; then
```

This caused bison to fail, which in turn caused bash dev-build to fail.