### PR TITLE
Failures improvement

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -7,10 +7,10 @@
 AUTOCONF_VERSION="2.71"
 export ZOPEN_BUILD_LINE="STABLE"
 export ZOPEN_STABLE_URL="https://ftp.gnu.org/gnu/autoconf/autoconf-${AUTOCONF_VERSION}.tar.gz"
-export ZOPEN_STABLE_DEPS="curl gzip make m4 perl zlib texinfo automake autoconf "
+export ZOPEN_STABLE_DEPS="curl gzip make m4 perl zlib texinfo automake autoconf bash flex"
 
 export ZOPEN_DEV_URL="https://github.com/autotools-mirror/autoconf.git"
-export ZOPEN_DEV_DEPS="git make m4 perl autoconf automake help2man texinfo xz zlib"
+export ZOPEN_DEV_DEPS="git make m4 perl autoconf automake help2man texinfo xz zlib bash flex"
 
 export ZOPEN_EXTRA_CFLAGS=""
 export ZOPEN_EXTRA_LDFLAGS=""

--- a/patches/m4sh.m4.patch
+++ b/patches/m4sh.m4.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/m4sugar/m4sh.m4 b/lib/m4sugar/m4sh.m4
+index ce53152..e8e61cf 100644
+--- a/lib/m4sugar/m4sh.m4
++++ b/lib/m4sugar/m4sh.m4
+@@ -741,7 +741,7 @@ as_unset=as_fn_unset
+ # a variable that is not already set.  You should not unset MAIL and
+ # MAILCHECK, as that triggers a bug in Bash 2.01.
+ m4_defun([AS_UNSET],
+-[{ AS_LITERAL_WORD_IF([$1], [], [eval ])$1=; unset $1;}])
++[{ AS_LITERAL_WORD_IF([$1], [], [eval ]) unset $1;}])
+ 
+ 
+ 


### PR DESCRIPTION
`$1=` is not necessary and causes issues with /bin/sh when doing it for known variables like `LINENO=`:
```
LINENO=
FSUM6659 syntax error in arithmetic expression "" near ""
```
Also adds flex which allows for 2 additional passes.

In zoscan2b, I now see 12 failures.